### PR TITLE
[FIX] switch from account_default_draft move to account_move_locking

### DIFF
--- a/common_accounting_profile/__openerp__.py
+++ b/common_accounting_profile/__openerp__.py
@@ -28,6 +28,8 @@
         "depends" : [
             'account_accountant',
             'account_constraints',
+            'account_cancel',
+            'account_move_locking',
             'account_financial_report_webkit',
             'account_financial_report_webkit_xls',
             'account_journal_report_xls',


### PR DESCRIPTION
We have define that accont_default_draft_move must be replace by
- account_move_locking
- account_cancel

And account_constraint is not useful anymore
